### PR TITLE
Fix total page parser logic.

### DIFF
--- a/lib/src/albiruni_base.dart
+++ b/lib/src/albiruni_base.dart
@@ -59,7 +59,7 @@ class Albiruni {
   /// One page holds about 50 entries. Navigate to the next page using the [page] parameter. Default is `1`.
   ///
   /// Returns a Records of list of [Subject] and total pages.
-  Future<(List<Subject>, int)> fetch(String kulliyah,
+  Future<(List<Subject> subjects, int totalPages)> fetch(String kulliyah,
       {String? course, int page = 1}) async {
     var processedCourse =
         course != null ? course.replaceFirst(' ', '+').toUpperCase() : '';

--- a/lib/src/util/parse_albiruni_html.dart
+++ b/lib/src/util/parse_albiruni_html.dart
@@ -7,7 +7,7 @@ import 'package:html/parser.dart';
 import '../model/subject.dart';
 
 /// Parse raw Albiruni body (HTML) to list of [Subject]
-(List<Subject>, int) parseAlbiruniHtml(String htmlBody) {
+(List<Subject> subjects, int totalPages) parseAlbiruniHtml(String htmlBody) {
   List<Subject> subjects = [];
   var document = parse(htmlBody);
   var elements = document.getElementsByTagName("tbody");
@@ -106,21 +106,27 @@ Subject parseSubject(Element element) {
   );
 }
 
-/// Parse total pages from a scope
-///
-/// JS equivalent:
-/// var tdElement = document.getElementsByTagName("tbody")[1].children[0].querySelector("td[colspan]");
-/// var aElements = tdElement.querySelectorAll("a");
-/// Array.prototype.filter.call(tdElement.children, function(child) {
-///   return child.nodeName === "A";
-/// }).length;
+/// Parse total pages from a pagination row element
 int parseTotalPages(Element element) {
-  var res = element
-      .querySelector("td")!
-      .children
-      .where((element) => element.localName == "a")
+  var td = element.querySelector("td")!;
+
+  if (td.children.isEmpty) {
+    // No pagination links, so only 1 page exists.
+    // Screenshot: https://imgur.com/mb2xmFl
+    return 1;
+  }
+
+  // Count numeric <a> elements (page links), excluding nav buttons like PREV/NEXT.
+  // Screenshot: https://imgur.com/cgiqYib
+  var numericLinks = td.children
+      .where((e) => e.localName == "a" && int.tryParse(e.text.trim()) != null)
       .length;
 
-  // When no <a> element exist, which means this scope has no other pages, only one page
-  return res == 0 ? 1 : res;
+  // Count <b> elements with numeric text — the current page is shown in bold,
+  // not as an <a> link.
+  var boldCurrentPages = td.children
+      .where((e) => e.localName == "b" && int.tryParse(e.text.trim()) != null)
+      .length;
+
+  return numericLinks + boldCurrentPages;
 }

--- a/test/src/util/parse_albiruni_html_test.dart
+++ b/test/src/util/parse_albiruni_html_test.dart
@@ -5,8 +5,7 @@ import 'package:test/test.dart';
 
 void main() {
   test('Test parser (HTML to Albiruni object)', () async {
-    String rawResponse =
-        '''
+    String rawResponse = '''
 <html>
 <head>
 <title>Course Schedule</title>
@@ -227,8 +226,7 @@ else {
 
   test('Parse Subject from HTML element (Multiple lecturers, no venue)', () {
     // from ENGINE 2022/2023 Semester 1
-    var rawElement = Element.html(
-        '''
+    var rawElement = Element.html('''
  <tr bgcolor=f5f5f5 valign="top">
                 <td width="9%" align="left"  >BTEN 3183</td>
                 <td width="3%" align="left" >2</td>
@@ -272,8 +270,7 @@ else {
 
   test('Parse Subject from HTML element (Multiple days)', () {
     // from KICT 2022/2023 Semester 1
-    var rawElement = Element.html(
-        '''
+    var rawElement = Element.html('''
 </tr>
               <tr bgcolor=ddddf5 valign="top">
                 <td width="9%" align="left"  >CSCI 4347</td>
@@ -311,8 +308,7 @@ else {
 
   test('Parse Subject from HTML element (Multiple days with tuto time)', () {
     // from KICT 2022/2023 Semester 1
-    var rawElement = Element.html(
-        '''
+    var rawElement = Element.html('''
 <tr bgcolor=ddddf5 valign="top">
                 <td width="9%" align="left"  >INFO 1303</td>
                 <td width="3%" align="left" >2</td>
@@ -356,8 +352,7 @@ else {
   });
 
   test('Parse subject from HTML (Multiple lect, only one day time)', () {
-    var rawElement = Element.html(
-        '''
+    var rawElement = Element.html('''
 <tr bgcolor="f5f5f5" valign="top">
                 <td width="9%" align="left">CCUB 3164</td>
                 <td width="3%" align="left">29</td>
@@ -390,10 +385,74 @@ else {
         containsOnce(DayTime(day: 3, startTime: '15:30', endTime: '16:30')));
   });
 
+  group('parseTotalPages', () {
+    Element paginationRow(String innerHtml) =>
+        Element.html('<tr><td colspan=5>$innerHtml</td></tr>');
+
+    test('Single page (no pagination links)', () {
+      var element = paginationRow('');
+      expect(parseTotalPages(element), 1);
+    });
+
+    test('First page (current page bold, rest as links, NEXT button)', () {
+      // Simulates being on page 1 of 12: <B>1</B> 2 3 ... 12 NEXT
+      var element = paginationRow('<B>1</B>&nbsp;&nbsp;'
+          '<a href="#">2</a>&nbsp;&nbsp;'
+          '<a href="#">3</a>&nbsp;&nbsp;'
+          '<a href="#">4</a>&nbsp;&nbsp;'
+          '<a href="#">5</a>&nbsp;&nbsp;'
+          '<a href="#">6</a>&nbsp;&nbsp;'
+          '<a href="#">7</a>&nbsp;&nbsp;'
+          '<a href="#">8</a>&nbsp;&nbsp;'
+          '<a href="#">9</a>&nbsp;&nbsp;'
+          '<a href="#">10</a>&nbsp;&nbsp;'
+          '<a href="#">11</a>&nbsp;&nbsp;'
+          '<a href="#">12</a>&nbsp;&nbsp;'
+          '<a href="#">NEXT</a>');
+      expect(parseTotalPages(element), 12);
+    });
+
+    test('Middle page (PREV, numeric links, current page bold, NEXT)', () {
+      // Simulates being on page 5 of 12: PREV 1 2 3 4 <B>5</B> 6 ... 12 NEXT
+      var element = paginationRow('<a href="#">PREV</a>&nbsp;&nbsp;'
+          '<a href="#">1</a>&nbsp;&nbsp;'
+          '<a href="#">2</a>&nbsp;&nbsp;'
+          '<a href="#">3</a>&nbsp;&nbsp;'
+          '<a href="#">4</a>&nbsp;&nbsp;'
+          '<B>5</B>&nbsp;&nbsp;'
+          '<a href="#">6</a>&nbsp;&nbsp;'
+          '<a href="#">7</a>&nbsp;&nbsp;'
+          '<a href="#">8</a>&nbsp;&nbsp;'
+          '<a href="#">9</a>&nbsp;&nbsp;'
+          '<a href="#">10</a>&nbsp;&nbsp;'
+          '<a href="#">11</a>&nbsp;&nbsp;'
+          '<a href="#">12</a>&nbsp;&nbsp;'
+          '<a href="#">NEXT</a>');
+      expect(parseTotalPages(element), 12);
+    });
+
+    test('Last page (PREV, numeric links, current page bold)', () {
+      // Simulates being on page 12 of 12: PREV 1 2 ... 11 <B>12</B>
+      var element = paginationRow('<a href="#">PREV</a>&nbsp;&nbsp;'
+          '<a href="#">1</a>&nbsp;&nbsp;'
+          '<a href="#">2</a>&nbsp;&nbsp;'
+          '<a href="#">3</a>&nbsp;&nbsp;'
+          '<a href="#">4</a>&nbsp;&nbsp;'
+          '<a href="#">5</a>&nbsp;&nbsp;'
+          '<a href="#">6</a>&nbsp;&nbsp;'
+          '<a href="#">7</a>&nbsp;&nbsp;'
+          '<a href="#">8</a>&nbsp;&nbsp;'
+          '<a href="#">9</a>&nbsp;&nbsp;'
+          '<a href="#">10</a>&nbsp;&nbsp;'
+          '<a href="#">11</a>&nbsp;&nbsp;'
+          '<B>12</B>');
+      expect(parseTotalPages(element), 12);
+    });
+  });
+
   test('Parse Subject from HTML element (No time, no venue)', () {
     // from ENMS 2022/2023 Semester 1
-    var rawElement = Element.html(
-        '''
+    var rawElement = Element.html('''
 <tr bgcolor="ddddf5" valign="top">
                 <td width="9%" align="left">ISF 4214</td>
                 <td width="3%" align="left">1</td>


### PR DESCRIPTION
This PR fixes the bug on inconsitent total page being returned. Closes #13.

Now, it correctly parses the total page number consistently.

<img width="355" height="178" alt="image" src="https://github.com/user-attachments/assets/4af5dca5-d63e-4203-a944-55b4ed28cf04" />

Test results:

<img width="349" height="562" alt="image" src="https://github.com/user-attachments/assets/70772644-463e-4d7d-8cde-2eefa3f08870" />