### PR TITLE
Fix incorrect handling of course parameter when fetching from source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.5.2
+
+- :bug: Fixes a bug where searching for course will throw an error. Issue [#15](https://github.com/iiumschedule/albiruni/issues/15)
+
 ## 1.5.1
 
 - :bug: Fixes a bug where totalPage value were being inconsistent. Issue [#13](https://github.com/iiumschedule/albiruni/issues/13)

--- a/lib/src/albiruni_base.dart
+++ b/lib/src/albiruni_base.dart
@@ -61,13 +61,12 @@ class Albiruni {
   /// Returns a Records of list of [Subject] and total pages.
   Future<(List<Subject> subjects, int totalPages)> fetch(String kulliyah,
       {String? course, int page = 1}) async {
-    var processedCourse =
-        course != null ? course.replaceFirst(' ', '+').toUpperCase() : '';
-
     var queryParams = _getBasicQueryParams();
     queryParams['kuly'] = kulliyah;
     queryParams['view'] = (page * 50).toString();
-    queryParams['course'] = processedCourse;
+    if (course != null) {
+      queryParams['course'] = course.toAlbiruniFormat();
+    }
 
     var uri = Uri.https(_host, _path, queryParams);
     var res = await http.get(uri);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: albiruni
 description: A wrapper to easily access IIUM's Course Schedule data.
-version: 1.5.1
+version: 1.5.2
 repository: https://github.com/iqfareez/albiruni
 issue_tracker: https://github.com/iqfareez/albiruni/issues
 topics:


### PR DESCRIPTION
This PR fixes issue where we cannot search using course code. Closes #15.

Result:

Now, it can fetch correctly.

<img width="843" height="753" alt="Screenshot 2026-04-04 at 9 36 42 AM" src="https://github.com/user-attachments/assets/0ffd4cdf-d0db-435f-91a9-d8a27b70d4aa" />

Test results:

All passed

<img width="307" height="630" alt="Screenshot 2026-04-04 at 9 37 17 AM" src="https://github.com/user-attachments/assets/d67c4a6b-f48c-415b-9c2b-5c507ef0cb2a" />